### PR TITLE
Have a receiveBuffer per socket, instead of global

### DIFF
--- a/TalkerNode.js
+++ b/TalkerNode.js
@@ -193,12 +193,13 @@ function sendData(socket, data) {
 	}
 }
 
-var receiveBuffer = '';
 /*
  * Method executed when data is received from a socket
  */
 function receiveData(socket, data) {
-
+	if(socket.receiveBuffer === undefined) {
+	    socket.receiveBuffer = '';
+	}
 	// Detect IAC commands
 	if(data[0] == 0xFF) {
 		// TODO: We're just filtering out IAC commands. We should be dealing with them instead...
@@ -209,23 +210,23 @@ function receiveData(socket, data) {
 
 	// Buffer received data and wait for newline before processing
 	// Fixes #121 (Windows uses character mode rather than line mode)
-	receiveBuffer += data;
-	if (receiveBuffer.indexOf('\r\n') === -1)
+	socket.receiveBuffer += data;
+	if (socket.receiveBuffer.indexOf('\r\n') === -1)
 		return;
 
 	// Clean input
-	var cleanData = cleanInput(receiveBuffer);
+	var cleanData = cleanInput(socket.receiveBuffer);
 
 	if(cleanData.length == 0)
 		return;
 
 
 	// Useful when in debug mode, you don't want this otherwise... it wouldn't be nice for your users' privacy, would it?
-	// console.log('Moo: Buf:', receiveBuffer);
+	// console.log('Moo: Buf:', socket.receiveBuffer);
 	// console.log("Moo [" + cleanData + "]");
 
 	// Empty the receive buffer, ready for the next input...
-	receiveBuffer = '';
+	socket.receiveBuffer = '';
 
 	sendData(socket, echo(true));
 	if(socket.username == undefined) {


### PR DESCRIPTION
We don't want to mix up content received from different clients into
the same buffer, each client/socket should have its own buffer.

I'm creating this PR to you since I'm flying blind here: this seems to me to make sense and needed, but since you seem to actually being able to test it...

AFAICS, your patch creates a global buffer, so if we have several simultaneous clients, and at least one of them is using character mode, then the content will be mixed between clients. My patch just changes the buffer being used, from a global one into a buffer per socket.

If you could test this, it would be greatly appreciated!